### PR TITLE
libretuya: add support for remote_receiver/transmitter

### DIFF
--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -31,7 +31,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
                 cv.percentage_int, cv.Range(min=0)
             ),
             cv.SplitDefault(
-                CONF_BUFFER_SIZE, esp32="10000b", esp8266="1000b"
+                CONF_BUFFER_SIZE, esp32="10000b", esp8266="1000b", libretuya="1000b"
             ): cv.validate_bytes,
             cv.Optional(
                 CONF_FILTER, default="50us"

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace remote_receiver {
 
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(USE_LIBRETUYA)
 struct RemoteReceiverComponentStore {
   static void gpio_intr(RemoteReceiverComponentStore *arg);
 
@@ -55,7 +55,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   esp_err_t error_code_{ESP_OK};
 #endif
 
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(USE_LIBRETUYA)
   RemoteReceiverComponentStore store_;
   HighFrequencyLoopRequester high_freq_;
 #endif

--- a/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
@@ -3,7 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(USE_LIBRETUYA)
 
 namespace esphome {
 namespace remote_receiver {

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -28,7 +28,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(USE_LIBRETUYA)
   void calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period, uint32_t *off_time_period);
 
   void mark_(uint32_t on_time, uint32_t off_time, uint32_t usec);

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -38,12 +38,14 @@ void RemoteTransmitterComponent::await_target_time_() {
   if (this->target_time_ == 0) {
     this->target_time_ = current_time;
 #ifndef USE_LIBRETUYA
-   } else if (this->target_time_ > current_time) {
-     delayMicroseconds(this->target_time_ - current_time);
-   }
+  } else if (this->target_time_ > current_time) {
+    delayMicroseconds(this->target_time_ - current_time);
+  }
 #else
-  } else while (this->target_time_ > micros()) {
-    // busy loop that ensures micros is constantly called
+  } else {
+    while (this->target_time_ > micros()) {
+      // busy loop that ensures micros is constantly called
+    }
   }
 #endif
 }

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(USE_LIBRETUYA)
 
 namespace esphome {
 namespace remote_transmitter {
@@ -37,9 +37,15 @@ void RemoteTransmitterComponent::await_target_time_() {
   const uint32_t current_time = micros();
   if (this->target_time_ == 0) {
     this->target_time_ = current_time;
-  } else if (this->target_time_ > current_time) {
-    delayMicroseconds(this->target_time_ - current_time);
+#ifndef USE_LIBRETUYA
+   } else if (this->target_time_ > current_time) {
+     delayMicroseconds(this->target_time_ - current_time);
+   }
+#else
+  } else while (this->target_time_ > micros()) {
+    // busy loop that ensures micros is constantly called
   }
+#endif
 }
 
 void RemoteTransmitterComponent::mark_(uint32_t on_time, uint32_t off_time, uint32_t usec) {
@@ -77,6 +83,9 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->target_time_ = 0;
   for (uint32_t i = 0; i < send_times; i++) {
+#ifdef USE_LIBRETUYA
+    InterruptLock lock;
+#endif
     for (int32_t item : this->temp_.get_data()) {
       if (item > 0) {
         const auto length = uint32_t(item);


### PR DESCRIPTION
# What does this implement/fix?
Adds support for `remote_receiver` and `remote_transmitter`. While it might not be the cleanest solution, I'm putting it out here to either gather feedback or get it merged in.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/kuba2k2/libretuya/issues/69

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] LIBRETUYA (`wb3s` board)

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote_transmitter:
  pin: P26
  carrier_duty_percent: 50%

remote_receiver:
  id: ir_receiver
  pin:
    number: P8
    inverted: true
  dump: raw
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
