### PR TITLE
Add support for remote transmitter

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -28,7 +28,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(LT_BOARD)
   void calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period, uint32_t *off_time_period);
 
   void mark_(uint32_t on_time, uint32_t off_time, uint32_t usec);

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-#ifdef USE_ESP8266
+#if defined(USE_ESP8266) || defined(LT_BOARD)
 
 namespace esphome {
 namespace remote_transmitter {

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tzlocal==4.2    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
 platformio==6.1.6  # When updating platformio, also update Dockerfile
-esptool==4.4
+esptool==4.5.dev2
 click==8.1.3
 libretuya-esphome-dashboard
 aioesphomeapi==13.3.1


### PR DESCRIPTION
# What does this implement/fix?

This allow using remote-transmitter component with LibreTuya-esphome

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Right now, the component wouldn't compile, since it's only testing for ESP32 and ESP8266

I've changed the ifdef block so the code does build.
I also had to upgrade the esptool version since the version in the repository depends on buggy reedsolomon python module that doesn't build anymore. This was fixed upstream so upgrading the version is the easiest solution


## Warnings

I wasn't able to get the remote transmitter to work fully.

When I put an oscilloscope on the IR led, I see the signal is going through (PWM signal with 50% duty at 38.4kHz) but the amplitude is way too low (max 1.2V on the led, while it should be 3.3V). I think something is fishy on the GPIO pull-up/pull-down declaration so maybe the transistor can't full switch the line but I couldn't figure out where to change this setting for PWM modules.

If you have an idea to fix it?

