### PR TITLE
libretiny: add manufacturer to HA API response

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1050,6 +1050,8 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.manufacturer = "Espressif";
 #elif defined(USE_RP2040)
   resp.manufacturer = "Raspberry Pi";
+#elif defined(USE_LIBRETINY)
+  resp.manufacturer = "LibreTiny";
 #elif defined(USE_HOST)
   resp.manufacturer = "Host";
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Show "LibreTiny" as manufacturer in the Homeassistant dashboard. Until now HA shows "espressif" as default manufacturer because the value is not set in the API response.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

