### PR TITLE
Updated versions on packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN \
         python3-venv=3.9.2-3 \
         iputils-ping=3:20210202-1 \
         git=1:2.30.2-1+deb11u2 \
-        curl=7.74.0-1.3+deb11u7 \
-        openssh-client=1:8.4p1-5+deb11u1 \
+        curl=7.74.0-1.3+deb11u9 \
+        openssh-client=1:8.4p1-5+deb11u2 \
         python3-cffi=1.14.5-1 \
         libcairo2=1.16.0-5 \
         patch=2.7.6-7; \


### PR DESCRIPTION
`curl` was updated to `7.74.0-1.3+deb11u9`, as `7.74.0-1.3+deb11u7` is no longer available.

openssh-client was updated to `1:8.4p1-5+deb11u2`, as `1:8.4p1-5+deb11u1` is no longer available.

# What does this implement/fix?

build script fails to execute successfully with currently listed packages in Dockerfile.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

